### PR TITLE
use threadstore lazy init

### DIFF
--- a/backend/api_server.py
+++ b/backend/api_server.py
@@ -99,8 +99,6 @@ class FileStorageConfig(BaseModel):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Lifespan context manager for database and file store initialization."""
-    logger.info("Initializing thread store...")
-    await thread_store.initialize()
     
     # Create file storage directory if it doesn't exist
     # Get the storage path from environment variable or use a default
@@ -211,11 +209,9 @@ app.add_middleware(
 )
 
 # Initialize thread store and agent
-# Construct PostgreSQL URL from environment variables
-db_url = f"postgresql+asyncpg://{os.getenv('TYLER_DB_USER')}:{os.getenv('TYLER_DB_PASSWORD')}@{os.getenv('TYLER_DB_HOST')}:{os.getenv('TYLER_DB_PORT')}/{os.getenv('TYLER_DB_NAME')}"
-
-# Initialize ThreadStore with PostgreSQL URL
-thread_store = ThreadStore(db_url)
+# ThreadStore will use environment variables to configure the database
+thread_store = ThreadStore()
+logger.info("Initialized thread store with environment-based configuration")
 
 # Initialize file store
 file_store = FileStore()

--- a/frontend/src/utils/version.ts
+++ b/frontend/src/utils/version.ts
@@ -9,8 +9,8 @@
 import axios from 'axios';
 
 // Local version information - SINGLE SOURCE OF TRUTH
-export const TYLER_CHAT_VERSION = '0.7.0'; // The version of this chat application itself
-export const TYLER_COMPATIBLE_VERSION = '0.7.0'; // Update this when testing with new Tyler versions
+export const TYLER_CHAT_VERSION = '0.8.0'; // The version of this chat application itself
+export const TYLER_COMPATIBLE_VERSION = '0.8.0'; // Update this when testing with new Tyler versions
 
 // Version information interface from backend
 export interface VersionInfo {


### PR DESCRIPTION
This pull request includes changes to the `backend/api_server.py` and `frontend/src/utils/version.ts` files to improve configuration handling and update version information.

Configuration improvements:

* [`backend/api_server.py`](diffhunk://#diff-62517ae8e9b1283c568b6e06ec076b30e85add98504db481b0588e647755df5bL214-R214): Removed hardcoded PostgreSQL URL construction and initialization of `ThreadStore` with environment variables. This simplifies the configuration process and improves flexibility.
* [`backend/api_server.py`](diffhunk://#diff-62517ae8e9b1283c568b6e06ec076b30e85add98504db481b0588e647755df5bL102-L103): Removed unnecessary initialization of `thread_store` in the `lifespan` context manager, which reduces redundancy.

Version updates:

* [`frontend/src/utils/version.ts`](diffhunk://#diff-c52bf4dc746798340c4ec7a6b66a25a3db936b45fc657ca9cbad8a4e08f45865L12-R13): Updated `TYLER_CHAT_VERSION` and `TYLER_COMPATIBLE_VERSION` to `0.8.0` to reflect the new version of the chat application and its compatibility.